### PR TITLE
Add PikaSim repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3400,3 +3400,10 @@ https://aalivexy.cc/fdroid/repo
 FD 1F A1 A8 EB AB 0C E3 72 01 3A D5 02 E7 42 B3 83 40 27 EA F4 AC 65 C9 E2 25 19 BA 5E 1A BC ED
 
 
+## PikaSim
+https://pikasim.com/fdroid/repo
+
+* fingerprint: *
+A0 0D EF CF B5 B9 14 DB F4 03 33 70 7A AC 51 30 F2 3C 62 23 18 47 8C 9D 3D 89 CD E1 9F 47 28 26
+
+

--- a/links.md
+++ b/links.md
@@ -94,3 +94,7 @@ https://briarproject.org/fdroid/repo?fingerprint=1FB874BEE7276D28ECB2C9B06E8A122
 ```
 https://guardianproject-wind.s3.amazonaws.com/fdroid/repo?fingerprint=182CF464D219D340DA443C62155198E399FEC1BC4379309B775DD9FC97ED97E1
 ```
+# PikaSim
+```
+https://pikasim.com/fdroid/repo?fingerprint=A00DEFCFB5B914DBF40333707AAC5130F23C622318478C9D3D89CDE19F472826
+```


### PR DESCRIPTION
Adds the **PikaSim** F-Droid repository to both `links.md` and `README.md` (alphabetical/appended, matching the existing entry format with the spaced fingerprint).

- **Repo:** `https://pikasim.com/fdroid/repo`
- **Fingerprint:** `A00DEFCFB5B914DBF40333707AAC5130F23C622318478C9D3D89CDE19F472826`

It's a live, self-hosted repo serving the PikaSim Android app (private, no-Google eSIM management). The repo index resolves and validates against the fingerprint above. Thanks for maintaining this list.
